### PR TITLE
Replaced typescript-memoize with a hand rolled memoization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "jquery": "3.6.1",
         "rxjs": "~7.5.0",
         "tslib": "^2.3.0",
-        "typescript-memoize": "^1.1.1",
         "zone.js": "~0.11.4"
       },
       "devDependencies": {
@@ -11316,11 +11315,6 @@
       "engines": {
         "node": ">=4.2.0"
       }
-    },
-    "node_modules/typescript-memoize": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/typescript-memoize/-/typescript-memoize-1.1.1.tgz",
-      "integrity": "sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA=="
     },
     "node_modules/ua-parser-js": {
       "version": "0.7.32",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "jquery": "3.6.1",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
-    "typescript-memoize": "^1.1.1",
     "zone.js": "~0.11.4"
   },
   "devDependencies": {

--- a/src/app/model/character.ts
+++ b/src/app/model/character.ts
@@ -1,4 +1,3 @@
-import { Memoize } from 'typescript-memoize';
 import { AoSelection } from './ao-selection';
 import CharacterAbilities from './character-abilities';
 import { SKILL_DEFAULT_ABILITIES } from './constants';
@@ -189,7 +188,6 @@ export default class Character {
    *
    * @returns The character's "Default" skills
    */
-  @Memoize()
   getDefaultSkills(): Skill[] {
     const ret: Skill[] = [];
     for (const key in this.defaultSkills) {

--- a/src/app/sheet/racial-abilities/racial-abilities.component.ts
+++ b/src/app/sheet/racial-abilities/racial-abilities.component.ts
@@ -1,5 +1,4 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { Memoize } from 'typescript-memoize';
 
 export interface AbilityModifiedEvent {
   oldName: string | null;

--- a/src/app/sheet/skill-grid/skill-grid.component.html
+++ b/src/app/sheet/skill-grid/skill-grid.component.html
@@ -1,5 +1,5 @@
 <div class="skill-grid">
-  <div *ngFor="let skill of character.getDefaultSkills(); let i = index">
+  <div *ngFor="let skill of defaultSkills; let i = index">
     <skill
       [skill]="skill"
       [abilityModifiers]="character.getAbilityModifiers()"

--- a/src/app/sheet/skill-grid/skillMemoUtils.ts
+++ b/src/app/sheet/skill-grid/skillMemoUtils.ts
@@ -1,0 +1,60 @@
+import Character from 'src/app/model/character';
+import { Skill } from 'src/app/model/skill';
+
+function stringHash(val: string) {
+  const prime = 31;
+  const split: string[] = [...val];
+  return split.reduce(
+    (acc: number, current: string) => acc * prime + current.charCodeAt(0),
+    0
+  );
+}
+
+export function skillHash(character: Character): number {
+  var ret = 0;
+  const prime = 31;
+  for (const key in character.defaultSkills) {
+    ret +=
+      prime * ret +
+      prime * stringHash(key) +
+      (character.defaultSkills as any)[key];
+  }
+
+  return ret;
+}
+
+function stringArrayEquals(a: string[], b: string[]): boolean {
+  if (a.length != b.length) {
+    return false;
+  }
+  return !a.find((s: string, index: number) => s !== b[index]);
+}
+
+function skillsEqual(current: Skill, other: Skill): boolean {
+  if (other.identifier !== current.identifier) {
+    return false;
+  }
+  if (other.rank !== current.rank) {
+    return false;
+  }
+  if (other.name !== current.name) {
+    return false;
+  }
+  if (!stringArrayEquals(current.defaultAbilities, other.defaultAbilities)) {
+    return false;
+  }
+  return true;
+}
+
+export function skillsArrayEqual(a: Skill[], b: Skill[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return (
+    a.reduce(
+      (equal: boolean, current: Skill, index: number) =>
+        equal && skillsEqual(current, b[index]),
+      true
+    ) || false
+  );
+}


### PR DESCRIPTION
The memoization library was memoizing too eagerly, and didn't seem to have a way to hash a getter based on the container.